### PR TITLE
Corrección siglas URI

### DIFF
--- a/documentos/temas/REST.md
+++ b/documentos/temas/REST.md
@@ -42,7 +42,7 @@ Las *peticiones* HTTP tienen varias partes diferenciadas:
   autenticación.
 - Un [comando HTTP como PUT o GET](https://developer.mozilla.org/es/docs/Web/HTTP/Methods)),
   que indique qué es lo que se quiere que haga.
-- Un URI, o *uniform resource locator*, un identificador único de un
+- Un URI, o *uniform resource identifier*, un identificador único de un
   recurso sobre cuyo estado se quiere actuar.
 - Un *cuerpo*, no siempre presente, que contiene los datos que se
   adjuntan a la petición; estos datos pueden ir añadidos como rutas o

--- a/documentos/temas/words.dic
+++ b/documentos/temas/words.dic
@@ -669,6 +669,7 @@ i
 idempotencia
 idempotente
 idempotentes
+identifier
 if
 image
 imagedb


### PR DESCRIPTION
Se corrige el significado de las siglas **URI** (_uniform resource identifier_) tal y como se ha comentado en clase.