### PR TITLE
Arreglando enlace a travis-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://github.com/JJ/CC/actions/workflows/lint-markdown.yml/badge.svg)](https://github.com/JJ/CC/actions/workflows/lint-markdown.yml)
 
-https://github.com/JJ/CC/actions/workflows/lint-markdown.yml/badge.svg
-
 *Cloud Computing I* es una asignatura anual del máster de ingeniería
 informática en la [UGR][ugr-website].
 


### PR DESCRIPTION
Por lo que he podido ver, el enlace del badge de travis CI estaba roto (404). Tras entrar en la dirección del repositorio en Travis, he visto que aunque sigue funcionando, han cambiado el formato del link. Así que he actualizado el enlace a Travis y la URL al Badge.