### PR TITLE
Añade 401 a error codes de `REST.md`

### DIFF
--- a/documentos/temas/REST.md
+++ b/documentos/temas/REST.md
@@ -176,7 +176,9 @@ error y se considera que el cliente debe hacer algo para repararlo.
   forma incorrecta.
 - **404** es el célebre no encontrado, pero debe usarse sólo cuando el
   recurso al que se refiere el URI no existe.
-- **403** no autorizado también se puede usar en estos casos.
+- **403** ó **401** no autorizado también se puede usar en estos casos. 
+  401 es similar a 403, con la diferencia de que para el segundo, la 
+  autenticación es posible.
 - **405**,
   [método no permitido](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405),
   se puede usar en ciertos casos cuando


### PR DESCRIPTION
### Descripción

PR que actualiza `REST.md` añadiendo el código de error HTTP **401**.

Tanto el código 401 como el 403 se utilizan para responder a peticiones donde el cliente tiene falta de permisos.

**401: unauthorized**. El cliente necesita autenticarse para obtener la respuesta solicitada.

**403: forbidden**. El cliente está correctamente autenticado (token válido), pero no tiene permisos para el URI solicitado.

Fuente: https://developer.mozilla.org/es/docs/Web/HTTP/Status#errores_de_cliente